### PR TITLE
Example usage of the CloudPosse tfstate module.

### DIFF
--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -6,6 +6,27 @@ provider "sym" {
   org = var.sym_org_slug
 }
 
+data "aws_caller_identity" "current" {}
+
+# You cannot create a new backend by simply defining this and then
+# immediately proceeding to "terraform apply". The S3 backend must
+# be bootstrapped according to the simple yet essential procedure in
+# https://github.com/cloudposse/terraform-aws-tfstate-backend#usage
+module "terraform_state_backend" {
+  source     = "cloudposse/tfstate-backend/aws"
+  version    = "0.38.1"
+  namespace  = "sym"
+  name       = "tfstate"
+  attributes = [data.aws_caller_identity.current.account_id]
+
+  terraform_backend_config_file_path = ""
+  terraform_backend_config_file_name = "backend.tf"
+
+  terraform_state_file = "prod/terraform.tfstate"
+  force_destroy        = false
+}
+
+
 # A Sym Runtime that executes your Flows.
 module "sym_runtime" {
   source = "../../modules/sym-runtime"

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -19,7 +19,7 @@ module "terraform_state_backend" {
   name       = "tfstate"
   attributes = [data.aws_caller_identity.current.account_id]
 
-  terraform_backend_config_file_path = ""
+  terraform_backend_config_file_path = "."
   terraform_backend_config_file_name = "backend.tf"
 
   terraform_state_file = "prod/terraform.tfstate"


### PR DESCRIPTION
This is an optional way to set up Terraform state for your configurations.

The CloudPosse module generates the S3 bucket, Dynamo Table, and the backend configuration file you need to use this state bucket with your configs. Note the special initialization procedure documented here: https://github.com/cloudposse/terraform-aws-tfstate-backend